### PR TITLE
Fix repeated field name in GetStatesResponse

### DIFF
--- a/protos/ledger_messages.proto
+++ b/protos/ledger_messages.proto
@@ -78,5 +78,5 @@ message GetStatesRequest {
 }
 
 message GetStatesResponse {
-  repeated State state = 1;
+  repeated State states = 1;
 }


### PR DESCRIPTION
“Use pluralized names for repeated fields”

https://developers.google.com/protocol-buffers/docs/style#repeated_fields
Signed-off-by: James Taylor <jamest@uk.ibm.com>